### PR TITLE
Feat: 카카오 로그인 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ build/
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/
+src/main/resources/.env
 
 ### Eclipse ###
 .apt_generated

--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,12 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:${junitVersion}")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${junitVersion}")
+
+
+    // Swagger
+    implementation 'io.springfox:springfox-swagger2:2.9.2'
+    implementation 'io.springfox:springfox-swagger-ui:2.9.2'
+
 }
 
 test {

--- a/src/main/java/org/scoula/auth/controller/AuthController.java
+++ b/src/main/java/org/scoula/auth/controller/AuthController.java
@@ -84,22 +84,7 @@ public class AuthController {
     public ResponseEntity<?> kakaoLogin(@RequestBody KakaoLoginDto kakaoLoginDto) {
         String code = kakaoLoginDto.getCode();
 
-        KakaoLoginInfoDto kakaoLoginInfoDto = authServiceImpl.kakaoLogin(code);
-
-        return ResponseEntity.ok(kakaoLoginInfoDto);
-    }
-
-    @ApiOperation(value = "카카오 로그인", notes = "카카오 계정으로 로그인")
-    @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "성공적으로 요청이 처리되었습니다.", response = AuthResponse.class),
-            @ApiResponse(code = 401, message = "잘못된 요청입니다."),
-            @ApiResponse(code = 500, message = "서버에서 오류가 발생했습니다.")
-    })
-    @PostMapping("/kakao")
-    public ResponseEntity<?> kakaoLogin(@RequestBody KakaoLoginDto kakaoLoginDto) {
-        String code = kakaoLoginDto.getCode();
-
-        KakaoLoginInfoDto kakaoLoginInfoDto = authServiceImpl.kakaoLogin(code);
+        KakaoLoginInfoDto kakaoLoginInfoDto = authService.kakaoLogin(code);
 
         return ResponseEntity.ok(kakaoLoginInfoDto);
     }

--- a/src/main/java/org/scoula/auth/controller/AuthController.java
+++ b/src/main/java/org/scoula/auth/controller/AuthController.java
@@ -1,10 +1,12 @@
 package org.scoula.auth.controller;
 
 import org.scoula.auth.dto.AuthResponse;
+import org.scoula.auth.dto.KakaoLoginDto;
 import org.scoula.auth.dto.LoginRequest;
 import org.scoula.auth.dto.SignupRequest;
 import org.scoula.auth.service.AuthServiceImpl;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,5 +27,20 @@ public class AuthController {
     @PostMapping("/signup")
     public AuthResponse signup(@RequestBody SignupRequest request) {
         return authServiceImpl.signup(request);
+    }
+
+    @PostMapping("/kakao")
+    public ResponseEntity<?> kakaoLogin(@RequestBody KakaoLoginDto kakaoLoginDto) {
+        String code = kakaoLoginDto.getCode();
+
+        AuthResponse authResponse = authServiceImpl.kakaoLogin(code);
+
+        return ResponseEntity.ok(authResponse);
+    }
+
+    @PostMapping("/kakaoSignup")
+    public ResponseEntity<?> kakaoSignup(@RequestBody KakaoLoginDto kakaoLoginDto) {
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/org/scoula/auth/controller/AuthController.java
+++ b/src/main/java/org/scoula/auth/controller/AuthController.java
@@ -1,5 +1,10 @@
 package org.scoula.auth.controller;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import lombok.extern.log4j.Log4j2;
 import org.scoula.auth.dto.AuthResponse;
 import org.scoula.auth.dto.KakaoLoginDto;
 import org.scoula.auth.dto.LoginRequest;
@@ -14,6 +19,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/auth")
+@Log4j2
+@Api(tags = "게시글관리")
 public class AuthController {
 
     @Autowired
@@ -29,6 +36,12 @@ public class AuthController {
         return authServiceImpl.signup(request);
     }
 
+    @ApiOperation(value = "카카오 로그인", notes = "카카오 계정으로 로그인")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "성공적으로 요청이 처리되었습니다.", response = AuthResponse.class),
+            @ApiResponse(code = 401, message = "잘못된 요청입니다."),
+            @ApiResponse(code = 500, message = "서버에서 오류가 발생했습니다.")
+    })
     @PostMapping("/kakao")
     public ResponseEntity<?> kakaoLogin(@RequestBody KakaoLoginDto kakaoLoginDto) {
         String code = kakaoLoginDto.getCode();

--- a/src/main/java/org/scoula/auth/controller/AuthController.java
+++ b/src/main/java/org/scoula/auth/controller/AuthController.java
@@ -5,10 +5,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import lombok.extern.log4j.Log4j2;
-import org.scoula.auth.dto.AuthResponse;
-import org.scoula.auth.dto.KakaoLoginDto;
-import org.scoula.auth.dto.LoginRequest;
-import org.scoula.auth.dto.SignupRequest;
+import org.scoula.auth.dto.*;
 import org.scoula.auth.service.AuthServiceImpl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -46,14 +43,8 @@ public class AuthController {
     public ResponseEntity<?> kakaoLogin(@RequestBody KakaoLoginDto kakaoLoginDto) {
         String code = kakaoLoginDto.getCode();
 
-        AuthResponse authResponse = authServiceImpl.kakaoLogin(code);
+        KakaoLoginInfoDto kakaoLoginInfoDto = authServiceImpl.kakaoLogin(code);
 
-        return ResponseEntity.ok(authResponse);
-    }
-
-    @PostMapping("/kakaoSignup")
-    public ResponseEntity<?> kakaoSignup(@RequestBody KakaoLoginDto kakaoLoginDto) {
-
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(kakaoLoginInfoDto);
     }
 }

--- a/src/main/java/org/scoula/auth/dto/KakaoLoginDto.java
+++ b/src/main/java/org/scoula/auth/dto/KakaoLoginDto.java
@@ -6,10 +6,9 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@Builder
-public class AuthResponse {
-    private String token;
-    private String nickname;
+public class KakaoLoginDto {
+    private String code;
 }

--- a/src/main/java/org/scoula/auth/dto/KakaoLoginInfoDto.java
+++ b/src/main/java/org/scoula/auth/dto/KakaoLoginInfoDto.java
@@ -1,0 +1,19 @@
+package org.scoula.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class KakaoLoginInfoDto {
+    private String id;
+    private String token;
+    private String nickname;
+    private String profile;
+    private String email;
+    private String birthday;
+}

--- a/src/main/java/org/scoula/auth/service/AuthService.java
+++ b/src/main/java/org/scoula/auth/service/AuthService.java
@@ -1,6 +1,7 @@
 package org.scoula.auth.service;
 
 import org.scoula.auth.dto.AuthResponse;
+import org.scoula.auth.dto.KakaoLoginInfoDto;
 import org.scoula.auth.dto.LoginRequest;
 import org.scoula.auth.dto.SignupRequest;
 
@@ -11,5 +12,5 @@ public interface AuthService {
 
     AuthResponse signup(SignupRequest request);
 
-    AuthResponse kakaoLogin(String code);
+    KakaoLoginInfoDto kakaoLogin(String code);
 }

--- a/src/main/java/org/scoula/auth/service/AuthService.java
+++ b/src/main/java/org/scoula/auth/service/AuthService.java
@@ -4,8 +4,12 @@ import org.scoula.auth.dto.AuthResponse;
 import org.scoula.auth.dto.LoginRequest;
 import org.scoula.auth.dto.SignupRequest;
 
+import java.util.LinkedHashMap;
+
 public interface AuthService {
     AuthResponse login(LoginRequest request);
 
     AuthResponse signup(SignupRequest request);
+
+    AuthResponse kakaoLogin(String code);
 }

--- a/src/main/java/org/scoula/auth/service/AuthServiceImpl.java
+++ b/src/main/java/org/scoula/auth/service/AuthServiceImpl.java
@@ -1,5 +1,6 @@
 package org.scoula.auth.service;
 
+import lombok.extern.slf4j.Slf4j;
 import org.scoula.auth.dto.AuthResponse;
 import org.scoula.auth.dto.LoginRequest;
 import org.scoula.auth.dto.SignupRequest;
@@ -7,9 +8,17 @@ import org.scoula.auth.mapper.AuthMapper;
 import org.scoula.common.util.JwtUtil;
 import org.scoula.user.domain.User;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
 
+import java.util.LinkedHashMap;
+
+@Slf4j
 @Service
 public class AuthServiceImpl implements AuthService {
 
@@ -19,7 +28,19 @@ public class AuthServiceImpl implements AuthService {
     @Autowired
     private JwtUtil jwtUtil;
 
+    @Autowired
+    private RestTemplate restTemplate;
+
     private BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+
+    @Value("${kakao.clientId}")
+    private String clientId; // 카카오 로그인 클라이언트 ID
+
+    @Value("${kakao.redirectUrl}")
+    private String redirectUri; // 카카오 로그인 redirectURL
+
+
 
     public AuthResponse login(LoginRequest request) {
         User user = authMapper.findByEmail(request.getEmail());
@@ -43,17 +64,91 @@ public class AuthServiceImpl implements AuthService {
 
         String encodedPw = passwordEncoder.encode(request.getPassword());
 
-        User user = new User();
-        user.setEmail(request.getEmail());
-        user.setPassword(encodedPw);
-        user.setName(request.getName());
-        user.setNickname(request.getNickname());
-        user.setAddress(request.getAddress());
-        user.setAdditionalPoint(0);
+        User user = User.builder()
+                .email(request.getEmail())
+                .password(encodedPw)
+                .name(request.getName())
+                .nickname(request.getNickname())
+                .address(request.getAddress())
+                .additionalPoint(0)
+                .build();
 
         authMapper.insertUser(user);
 
         String token = jwtUtil.generateToken(user.getEmail());
         return new AuthResponse(token, user.getNickname());
     }
+
+    @Override
+    public AuthResponse kakaoLogin(String code) {
+        String url = "https://kauth.kakao.com/oauth/token";
+
+        // 1. 헤더 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        // 2. 바디 설정
+        MultiValueMap<String, String> tokenParams = new LinkedMultiValueMap<>();
+        tokenParams.add("grant_type", "authorization_code");
+        tokenParams.add("client_id", clientId); // 본인 앱 키
+        log.info(clientId);
+        log.info(redirectUri);
+
+        tokenParams.add("redirect_uri", redirectUri); // 프론트에서 사용한 redirect_uri
+        tokenParams.add("code", code);
+
+        HttpEntity<MultiValueMap<String, String>> tokenRequest = new HttpEntity<>(tokenParams, headers);
+
+        // 요청
+        ResponseEntity<LinkedHashMap> tokenResponse = restTemplate.postForEntity(url, tokenRequest, LinkedHashMap.class);
+
+        String accessToken = "Bearer "+ tokenResponse.getBody().get("access_token");;
+
+        LinkedHashMap<String, Object> userInfo = fetchKakaoUserData(accessToken);
+
+        String kakaoEmail = userInfo.get("email").toString();
+
+        User user = authMapper.findByEmail(kakaoEmail);
+
+        if (user != null) {
+            String token = jwtUtil.generateToken(kakaoEmail);
+            String nickname = user.getNickname();
+
+            AuthResponse authResponse = AuthResponse.builder()
+                    .token(token)
+                    .nickname(nickname)
+                    .build();
+
+            return authResponse;
+        }
+        else {
+            AuthResponse authResponse = AuthResponse.builder()
+                    .token(null)
+                    .nickname("회원가입해람마")
+                    .build();
+
+            return authResponse;
+        }
+    }
+
+    // kakaoAccessToken을 사용하여 카카오 서버로부터 유저 정보 받아오기
+    private LinkedHashMap<String, Object> fetchKakaoUserData(String kakaoAccessToken) {
+
+        String url = "https://kapi.kakao.com/v2/user/me";
+        RestTemplate restTemplate = new RestTemplate();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.set("Authorization", kakaoAccessToken);
+
+        HttpEntity<?> http = new HttpEntity<>(headers);
+
+        ResponseEntity<LinkedHashMap> response = restTemplate.exchange(url, HttpMethod.GET, http, LinkedHashMap.class);
+
+        Long id = (Long) response.getBody().get("id");
+        LinkedHashMap<String, Object> value = (LinkedHashMap<String, Object>) response.getBody().get("kakao_account");
+
+        return value;
+    }
+
 }

--- a/src/main/java/org/scoula/config/RootConfig.java
+++ b/src/main/java/org/scoula/config/RootConfig.java
@@ -12,6 +12,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.web.client.RestTemplate;
 
 import javax.sql.DataSource;
 
@@ -60,6 +61,10 @@ public class RootConfig {
         return new DataSourceTransactionManager(dataSource());
     }
 
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
 }
 
 

--- a/src/main/java/org/scoula/config/ServletConfig.java
+++ b/src/main/java/org/scoula/config/ServletConfig.java
@@ -24,6 +24,19 @@ public class ServletConfig implements WebMvcConfigurer {
         registry
                 .addResourceHandler("/resources/**") // url이 /resources/로 시작하는 모든 경로
                 .addResourceLocations("/resources/"); // webapp/resources/경로로 매핑
+
+        // Swagger UI 리소스를위한핸들러설정
+        registry.addResourceHandler("/swagger-ui.html")
+                .addResourceLocations("classpath:/META-INF/resources/");
+        // Swagger WebJar 리소스설정
+        registry.addResourceHandler("/webjars/**")
+                .addResourceLocations("classpath:/META-INF/resources/webjars/");
+        // Swagger 리소스설정
+        registry.addResourceHandler("/swagger-resources/**")
+                .addResourceLocations("classpath:/META-INF/resources/");
+        registry.addResourceHandler("/v2/api-docs")
+                .addResourceLocations("classpath:/META-INF/resources/");
+
     }
 
     // jsp view resolver 설정 - 뷰 이름을 JSP나 템플릿으로 매핑

--- a/src/main/java/org/scoula/config/SwaggerConfig.java
+++ b/src/main/java/org/scoula/config/SwaggerConfig.java
@@ -1,0 +1,42 @@
+package org.scoula.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.bind.annotation.RestController;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+@Configuration
+@EnableSwagger2
+public class SwaggerConfig {
+    private final String API_NAME = "청약 API";
+    private final String API_VERSION = "1.0";
+    private final String API_DESCRIPTION = "MyHomeCatch API 명세서";
+
+    private ApiInfo apiInfo() {
+        return new ApiInfoBuilder()
+                .title(API_NAME)
+                .description(API_DESCRIPTION)
+                .version(API_VERSION)
+                .build();
+    }
+
+
+
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .select()
+                .apis(RequestHandlerSelectors.withClassAnnotation(RestController.class))
+                .paths(PathSelectors.any())
+                .build()
+                .apiInfo(apiInfo());
+    }
+
+
+}

--- a/src/main/java/org/scoula/config/WebConfig.java
+++ b/src/main/java/org/scoula/config/WebConfig.java
@@ -21,13 +21,18 @@ public class WebConfig extends AbstractAnnotationConfigDispatcherServletInitiali
 
     @Override
     protected Class<?>[] getServletConfigClasses() {
-        return new Class[] {ServletConfig.class};
+        return new Class[] {ServletConfig.class, SwaggerConfig.class};
     }
 
     // URI mapping pattern of DispatcherServlet(FrontController) / : 모든 요청에 대해 매핑
     @Override
     protected String[] getServletMappings() {
-        return new String[] {"/"};
+        return new String[] {
+                "/",
+                "/swagger-ui.html",
+                "/swagger-resources/**",
+                "/v2/api-docs",
+                "/webjars/**"};
     }
 
     // POST body 문자 인코딩 필터 설정- UTF-8 설정
@@ -50,5 +55,7 @@ public class WebConfig extends AbstractAnnotationConfigDispatcherServletInitiali
                 );
         registration.setMultipartConfig(multipartConfig);
     }
+
+
 
 }

--- a/src/main/java/org/scoula/user/domain/User.java
+++ b/src/main/java/org/scoula/user/domain/User.java
@@ -1,8 +1,10 @@
 package org.scoula.user.domain;
 
+import lombok.Builder;
 import lombok.Data;
 
 @Data
+@Builder
 public class User {
 
     private int userId;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,7 @@ jdbc.driver=net.sf.log4jdbc.sql.jdbcapi.DriverSpy
 jdbc.url=jdbc:log4jdbc:mysql://localhost:3306/scoula_db
 jdbc.username=scoula
 jdbc.password=1234
+
+
+kakao.clientId=b5cd13baf980b9b75f7494d8d4c946bd
+kakao.redirectUrl=http://localhost:5173/auth/kakao/callback

--- a/src/main/webapp/WEB-INF/views/error_page.jsp
+++ b/src/main/webapp/WEB-INF/views/error_page.jsp
@@ -16,7 +16,7 @@
     <title>Title</title>
 </head>
 <body>
-<h4> <c:out value="${exception.getMassage()}"> </c:out></h4>
+<h4> <c:out value="${exception.getMessage()}"> </c:out></h4>
 <ul>
   <c:forEach items="${exception.getStackTrace()}" var="stack">
     <li><c:out value="${stack}"> </c:out></li>


### PR DESCRIPTION
## #️⃣연관된 이슈
#4 

## 📝작업 내용
- 카카오 인증 코드(code)를 서버에 전달하여 액세스 토큰 요청
- 액세스 토큰을 통해 사용자 정보 (id, email) 가져오기 (닉네임은 현재 서버로부터 받아오지 못함, 추후 확인)
- 사용자 정보 기반으로 회원가입 또는 로그인 처리
- JWT 발급 및 프론트엔드에 전달

## 💬리뷰 요구사항(선택)