### PR TITLE
Feat: 자가진단 내용 저장, 삭제, 조회

### DIFF
--- a/src/main/java/org/scoula/selfCheck/controller/SelfCheckController.java
+++ b/src/main/java/org/scoula/selfCheck/controller/SelfCheckController.java
@@ -110,4 +110,23 @@ public class SelfCheckController {
 
         return ResponseEntity.ok(results);
     }
+
+    @PostMapping("/content/save")
+    public ResponseEntity<?> saveContent(@RequestHeader("Authorization") String tokenHeader,
+                                         @RequestBody SelfCheckRequestDto dto) {
+        int userId = extractUserIdFromToken(tokenHeader);
+        if (userId == -1) return ResponseEntity.badRequest().body("유효하지 않은 사용자입니다.");
+
+        selfCheckService.saveSelfCheckContent(dto, userId);
+        return ResponseEntity.ok("진단 내용 저장 완료");
+    }
+
+    @DeleteMapping("/content/delete")
+    public ResponseEntity<?> deleteContent(@RequestHeader("Authorization") String tokenHeader) {
+        int userId = extractUserIdFromToken(tokenHeader);
+        if (userId == -1) return ResponseEntity.badRequest().body("유효하지 않은 사용자입니다.");
+
+        selfCheckService.deleteSelfCheckContent(userId);
+        return ResponseEntity.ok("진단 내용 삭제 완료");
+    }
 }

--- a/src/main/java/org/scoula/selfCheck/controller/SelfCheckController.java
+++ b/src/main/java/org/scoula/selfCheck/controller/SelfCheckController.java
@@ -2,6 +2,7 @@ package org.scoula.selfCheck.controller;
 
 import org.scoula.auth.mapper.AuthMapper;
 import org.scoula.common.util.JwtUtil;
+import org.scoula.selfCheck.dto.SelfCheckContentDto;
 import org.scoula.selfCheck.dto.SelfCheckRequestDto;
 import org.scoula.selfCheck.mapper.SelfCheckMapper;
 import org.scoula.selfCheck.service.SelfCheckService;
@@ -128,5 +129,18 @@ public class SelfCheckController {
 
         selfCheckService.deleteSelfCheckContent(userId);
         return ResponseEntity.ok("진단 내용 삭제 완료");
+    }
+
+    @GetMapping("/content")
+    public ResponseEntity<?> getSelfCheckContent(@RequestHeader("Authorization") String tokenHeader) {
+        int userId = extractUserIdFromToken(tokenHeader);
+        if (userId == -1) return ResponseEntity.badRequest().body("사용자를 찾을 수 없습니다.");
+
+        SelfCheckContentDto content = selfCheckService.getSelfCheckContent(userId);
+        if (content == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("진단 내용이 없습니다.");
+        }
+
+        return ResponseEntity.ok(content);
     }
 }

--- a/src/main/java/org/scoula/selfCheck/dto/SelfCheckContentDto.java
+++ b/src/main/java/org/scoula/selfCheck/dto/SelfCheckContentDto.java
@@ -1,0 +1,22 @@
+package org.scoula.selfCheck.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SelfCheckContentDto {
+    private int userId;
+    private int residencePeriod;
+    private String isHomeless;
+    private String houseHoldMembers;
+    private String maritalStatus;
+    private String monthlyIncome;
+    private String totalAssets;
+    private String carValue;
+    private String realEstateValue;
+    private String subscriptionPeriod;
+    private String targetGroups;
+}

--- a/src/main/java/org/scoula/selfCheck/dto/SelfCheckRequestDto.java
+++ b/src/main/java/org/scoula/selfCheck/dto/SelfCheckRequestDto.java
@@ -20,4 +20,8 @@ public class SelfCheckRequestDto {
     private String realEstateValue; // 부동산
     private String subscriptionPeriod; // 청약 가입 기간
     private List<String> targetGroups; // 해당사항
+
+    public String getTargetGroupsStr() {
+        return String.join(", ", targetGroups);
+    }
 }

--- a/src/main/java/org/scoula/selfCheck/mapper/SelfCheckMapper.java
+++ b/src/main/java/org/scoula/selfCheck/mapper/SelfCheckMapper.java
@@ -1,6 +1,7 @@
 package org.scoula.selfCheck.mapper;
 
 import org.apache.ibatis.annotations.Param;
+import org.scoula.selfCheck.dto.SelfCheckRequestDto;
 
 import java.util.List;
 
@@ -12,4 +13,7 @@ public interface SelfCheckMapper {
 
     List<String> findResultsByUserId(int userId);
 
+    void insertSelfCheckContent(@Param("dto") SelfCheckRequestDto dto, @Param("userId") int userId, @Param("targetGroupsStr") String targetGroupsStr);
+
+    void deleteSelfCheckContentByUserId(@Param("userId") int userId);
 }

--- a/src/main/java/org/scoula/selfCheck/mapper/SelfCheckMapper.java
+++ b/src/main/java/org/scoula/selfCheck/mapper/SelfCheckMapper.java
@@ -1,6 +1,7 @@
 package org.scoula.selfCheck.mapper;
 
 import org.apache.ibatis.annotations.Param;
+import org.scoula.selfCheck.dto.SelfCheckContentDto;
 import org.scoula.selfCheck.dto.SelfCheckRequestDto;
 
 import java.util.List;
@@ -16,4 +17,6 @@ public interface SelfCheckMapper {
     void insertSelfCheckContent(@Param("dto") SelfCheckRequestDto dto, @Param("userId") int userId, @Param("targetGroupsStr") String targetGroupsStr);
 
     void deleteSelfCheckContentByUserId(@Param("userId") int userId);
+
+    SelfCheckContentDto findSelfCheckContentByUserId(int userId);
 }

--- a/src/main/java/org/scoula/selfCheck/service/SelfCheckService.java
+++ b/src/main/java/org/scoula/selfCheck/service/SelfCheckService.java
@@ -1,5 +1,6 @@
 package org.scoula.selfCheck.service;
 
+import org.scoula.selfCheck.dto.SelfCheckContentDto;
 import org.scoula.selfCheck.dto.SelfCheckRequestDto;
 
 import java.util.Map;
@@ -17,4 +18,6 @@ public interface SelfCheckService {
     void saveSelfCheckContent(SelfCheckRequestDto dto, int userId);
 
     void deleteSelfCheckContent(int userId);
+
+    SelfCheckContentDto getSelfCheckContent(int userId);
 }

--- a/src/main/java/org/scoula/selfCheck/service/SelfCheckService.java
+++ b/src/main/java/org/scoula/selfCheck/service/SelfCheckService.java
@@ -13,4 +13,8 @@ public interface SelfCheckService {
     Map<String, Object> evaluateGongGong(SelfCheckRequestDto dto, int userId);
 
     Map<String, Object> evaluate09(SelfCheckRequestDto dto, int userId);
+
+    void saveSelfCheckContent(SelfCheckRequestDto dto, int userId);
+
+    void deleteSelfCheckContent(int userId);
 }

--- a/src/main/java/org/scoula/selfCheck/service/SelfCheckServiceImpl.java
+++ b/src/main/java/org/scoula/selfCheck/service/SelfCheckServiceImpl.java
@@ -1,5 +1,6 @@
 package org.scoula.selfCheck.service;
 
+import org.scoula.selfCheck.dto.SelfCheckContentDto;
 import org.scoula.selfCheck.dto.SelfCheckRequestDto;
 import org.scoula.selfCheck.mapper.SelfCheckMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -245,6 +246,11 @@ public class SelfCheckServiceImpl implements SelfCheckService{
     @Override
     public void deleteSelfCheckContent(int userId) {
         selfCheckMapper.deleteSelfCheckContentByUserId(userId);
+    }
+
+    @Override
+    public SelfCheckContentDto getSelfCheckContent(int userId) {
+        return selfCheckMapper.findSelfCheckContentByUserId(userId);
     }
 
     private void saveResultIfQualified(int userId, String result) {

--- a/src/main/java/org/scoula/selfCheck/service/SelfCheckServiceImpl.java
+++ b/src/main/java/org/scoula/selfCheck/service/SelfCheckServiceImpl.java
@@ -92,7 +92,7 @@ public class SelfCheckServiceImpl implements SelfCheckService{
                 case "청년 계층":
                 case "고령자 계층":
                     if (incomeScope.contains(income) && assetEligible) {
-                        resultText = "행복주택 가능 (" + group + ")";
+                        resultText = "행복주택 가능";
                         result.put("qualified", resultText);
                         saveResultIfQualified(userId, resultText);
                         return result;
@@ -111,7 +111,7 @@ public class SelfCheckServiceImpl implements SelfCheckService{
                         extendedIncomeScope.addAll(Arrays.asList("월평균 소득 120% 이하", "월평균 소득 110% 이하"));
                     }
                     if (extendedIncomeScope.contains(income) && assetEligible) {
-                        resultText = "행복주택 가능 (" + group + ")";
+                        resultText = "행복주택 가능";
                         result.put("qualified", resultText);
                         saveResultIfQualified(userId, resultText);
                         return result;
@@ -235,6 +235,16 @@ public class SelfCheckServiceImpl implements SelfCheckService{
         resultText = "영구임대 불가능";
         result.put("qualified", resultText);
         return result;
+    }
+
+    @Override
+    public void saveSelfCheckContent(SelfCheckRequestDto dto, int userId) {
+        selfCheckMapper.insertSelfCheckContent(dto, userId, dto.getTargetGroupsStr());
+    }
+
+    @Override
+    public void deleteSelfCheckContent(int userId) {
+        selfCheckMapper.deleteSelfCheckContentByUserId(userId);
     }
 
     private void saveResultIfQualified(int userId, String result) {

--- a/src/main/java/org/scoula/selfCheck/service/SelfCheckServiceImpl.java
+++ b/src/main/java/org/scoula/selfCheck/service/SelfCheckServiceImpl.java
@@ -64,7 +64,7 @@ public class SelfCheckServiceImpl implements SelfCheckService{
         String resultText;
 
         if (!"예".equals(dto.getIsHomeless())) {
-            resultText = "행복주택 불가능 (무주택자 아님)";
+            resultText = "행복주택 불가능";
             result.put("qualified", resultText);
             return result;
         }
@@ -97,7 +97,7 @@ public class SelfCheckServiceImpl implements SelfCheckService{
                         saveResultIfQualified(userId, resultText);
                         return result;
                     } else {
-                        resultText = "행복주택 불가능 (" + group + " 기준 불충족)";
+                        resultText = "행복주택 불가능";
                         result.put("qualified", resultText);
                         return result;
                     }
@@ -116,7 +116,7 @@ public class SelfCheckServiceImpl implements SelfCheckService{
                         saveResultIfQualified(userId, resultText);
                         return result;
                     } else {
-                        resultText = "행복주택 불가능 (" + group + " 기준 불충족)";
+                        resultText = "행복주택 불가능";
                         result.put("qualified", resultText);
                         return result;
                     }
@@ -127,14 +127,14 @@ public class SelfCheckServiceImpl implements SelfCheckService{
                 case "북한이탈주민":
                 case "아동복지시설 퇴소자":
                 case "고령 저소득자":
-                    resultText = "행복주택 우선공급 (" + group + ")";
+                    resultText = "행복주택 우선공급";
                     result.put("qualified", resultText);
                     saveResultIfQualified(userId, resultText);
                     return result;
             }
         }
 
-        resultText = "행복주택 불가능 (해당 계층 아님)";
+        resultText = "행복주택 불가능";
         result.put("qualified", resultText);
         return result;
     }
@@ -168,9 +168,9 @@ public class SelfCheckServiceImpl implements SelfCheckService{
         boolean isSpecialSupply = targets.stream().anyMatch(specialGroups::contains);
 
         if (isSpecialSupply) {
-            resultText = "공공분양 특별공급 대상";
+            resultText = "공공분양 특별공급";
         } else {
-            resultText = "공공분양 일반공급 가능";
+            resultText = "공공분양 가능";
         }
 
         if ("12개월 이상".equals(bankSavingPeriod) || "24개월 이상".equals(bankSavingPeriod)) {
@@ -199,7 +199,7 @@ public class SelfCheckServiceImpl implements SelfCheckService{
         String resultText = "";
 
         if (!isHomeless) {
-            resultText = "영구임대 불가능 (무주택 아님)";
+            resultText = "영구임대 불가능";
             result.put("qualified", resultText);
             return result;
         }
@@ -215,33 +215,13 @@ public class SelfCheckServiceImpl implements SelfCheckService{
             }
 
             switch (group) {
-                case "기초생활수급자":
-                    resultText = "영구임대 입주 가능 (기초생활수급자) 1순위";
+                case "기초생활수급자", "고령 저소득자", "한부모 가족", "위안부 피해자":
+                    resultText = "영구임대 가능 1순위";
                     break;
-                case "국가유공자":
+                case "국가유공자", "장애인", "북한이탈주민", "아동복지시설 퇴소자":
                     if (incomeOk && assetOk) {
-                        resultText = "영구임대 입주 가능 (국가유공자) 1순위";
+                        resultText = "영구임대 가능 1순위";
                     }
-                    break;
-                case "위안부 피해자":
-                    resultText = "영구임대 입주 가능 (위안부 피해자) 1순위";
-                    break;
-                case "한부모 가족":
-                    resultText = "영구임대 입주 가능 (한부모 가족) 1순위";
-                    break;
-                case "북한이탈주민":
-                case "아동복지시설 퇴소자":
-                    if (incomeOk && assetOk) {
-                        resultText = "영구임대 입주 가능 (" + group + ") 1순위";
-                    }
-                    break;
-                case "장애인":
-                    if (incomeOk && assetOk) {
-                        resultText = "영구임대 입주 가능 (장애인) 1순위";
-                    }
-                    break;
-                case "고령 저소득자":
-                    resultText = "영구임대 입주 가능 (고령 저소득자) 1순위";
                     break;
             }
 
@@ -252,7 +232,7 @@ public class SelfCheckServiceImpl implements SelfCheckService{
             }
         }
 
-        resultText = "영구임대 불가능 (1순위 조건 미충족)";
+        resultText = "영구임대 불가능";
         result.put("qualified", resultText);
         return result;
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,16 +1,16 @@
 #driver=com.mysql.cj.jdbc.Driver
 #url=jdbc:mysql://127.0.0.1:3306/scoula_db
 
-#jdbc.driver=net.sf.log4jdbc.sql.jdbcapi.DriverSpy
-#jdbc.url=jdbc:log4jdbc:mysql://myhomecatch.cpw20yo0imjn.ap-southeast-2.rds.amazonaws.com:3306/MyHomeCatch
-#jdbc.username=root
-#jdbc.password=myhomecatch
+jdbc.driver=net.sf.log4jdbc.sql.jdbcapi.DriverSpy
+jdbc.url=jdbc:log4jdbc:mysql://myhomecatch.cpw20yo0imjn.ap-southeast-2.rds.amazonaws.com:3306/MyHomeCatch
+jdbc.username=root
+jdbc.password=myhomecatch
 LH_API_SERVICE_KEY=EKnz94vtAe4ueCv7XJwzzUrA3HHKz2%2BDTAtvnHJNt5yjoVZMo%2Bqqk1hV%2FApwknZ0slBYc%2BXKooVXHoE8woxEpw%3D%3D
 
-jdbc.driver=net.sf.log4jdbc.sql.jdbcapi.DriverSpy
-jdbc.url=jdbc:log4jdbc:mysql://localhost:3306/scoula_db
-jdbc.username=scoula
-jdbc.password=1234
+#jdbc.driver=net.sf.log4jdbc.sql.jdbcapi.DriverSpy
+#jdbc.url=jdbc:log4jdbc:mysql://localhost:3306/scoula_db
+#jdbc.username=scoula
+#jdbc.password=1234
 
 #kakao.clientId=b5cd13baf980b9b75f7494d8d4c946bd
 #kakao.redirectUrl=http://localhost:5173/auth/loading

--- a/src/main/resources/org/scoula/selfCHeck/mapper/SelfCheckMapper.xml
+++ b/src/main/resources/org/scoula/selfCHeck/mapper/SelfCheckMapper.xml
@@ -36,4 +36,10 @@
         FROM self_check_content
         WHERE user_id = #{userId};
     </delete>
+
+    <select id="findSelfCheckContentByUserId" resultType="org.scoula.selfCheck.dto.SelfCheckContentDto">
+        SELECT *
+        FROM self_check_content
+        WHERE user_id = #{userId};
+    </select>
 </mapper>

--- a/src/main/resources/org/scoula/selfCHeck/mapper/SelfCheckMapper.xml
+++ b/src/main/resources/org/scoula/selfCHeck/mapper/SelfCheckMapper.xml
@@ -20,4 +20,20 @@
         FROM self_check_result
         WHERE user_id = #{userId};
     </select>
+
+    <insert id="insertSelfCheckContent">
+        INSERT INTO self_check_content (user_id, residence_period, is_homeless, household_members, marital_status,
+                                        monthly_income,
+                                        total_assets, car_value, real_estate_value, subscription_period, target_groups)
+        VALUES ( #{userId}, #{dto.residencePeriod}, #{dto.isHomeless}, #{dto.houseHoldMembers}, #{dto.maritalStatus}
+               , #{dto.monthlyIncome}
+               , #{dto.totalAssets}, #{dto.carValue}, #{dto.realEstateValue}, #{dto.subscriptionPeriod}
+               , #{targetGroupsStr});
+    </insert>
+
+    <delete id="deleteSelfCheckContentByUserId">
+        DELETE
+        FROM self_check_content
+        WHERE user_id = #{userId};
+    </delete>
 </mapper>


### PR DESCRIPTION
## 연관된 이슈

#32 

## 작업 내용
- 자격진단 내용 저장 API
- 자격진단 내용 삭제 API
- 자격진단 내용 조회 API
- refreshToken 생성
- refreshToken 활용하여 accessToken 활용

## API endpoint 사항
### SelfCheckController(`/api/self-check`)
 Method | Endpoint            | 설명                                                  |
|--------|---------------------|--------------------------------------|
| POST   | `/content/save` | 자격진단 내용 저장                                    |
| DELETE   | `/content/delete` | 자격진단 내용 삭제                                     |
| GET  | `/content` | 자격진단 내용 조회    |

### AuthController(`/api/auth`)
Method | Endpoint | 설명|
|-----|------|-------|
|POST|`/refresh`| 쿠키에 refreshToken 확인 후 토큰 갱신|

## SQL
```
CREATE TABLE self_check_content (
    user_id INT NOT NULL PRIMARY KEY,
    residence_period INT,                -- 거주기간 (개월)
    is_homeless VARCHAR(255),            -- 무주택 여부 (예/아니오)
    household_members VARCHAR(255),      -- 가구원 수 (예: "3,1")
    marital_status VARCHAR(255),         -- 미혼 / 기혼
    monthly_income VARCHAR(255),         -- 예: "월평균 소득 90% 이하"
    total_assets VARCHAR(255),           -- 예: "총 자산 33,700만원 초과"
    car_value VARCHAR(255),              -- 예: "자동차 3,803만원 초과"
    real_estate_value VARCHAR(255),      -- 예: "부동산 215,500천원 초과"
    subscription_period VARCHAR(255),    -- 청약 가입 기간 (예: "12개월 이상")
    target_groups TEXT                   -- 대상 그룹 리스트 (쉼표 구분 문자열로 저장)
);
```
```
CREATE TABLE users_refresh_token (
    user_id INT PRIMARY KEY,
    refresh_token TEXT,
    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
    FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
);
```

### 스크린샷 (선택)

