### PR TITLE
Feat: 즐겨찾기 알림 기능 구현

### DIFF
--- a/src/main/java/org/scoula/bookmark/dto/BookmarkEmailInfo.java
+++ b/src/main/java/org/scoula/bookmark/dto/BookmarkEmailInfo.java
@@ -1,0 +1,15 @@
+package org.scoula.bookmark.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class BookmarkEmailInfo {
+
+    private String email;
+    private String title;
+    private String type;
+}

--- a/src/main/java/org/scoula/bookmark/mapper/BookmarkMapper.java
+++ b/src/main/java/org/scoula/bookmark/mapper/BookmarkMapper.java
@@ -1,0 +1,11 @@
+package org.scoula.bookmark.mapper;
+
+import org.apache.ibatis.annotations.Param;
+import org.scoula.bookmark.dto.BookmarkEmailInfo;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface BookmarkMapper {
+    List<BookmarkEmailInfo> findAlertsForToday(@Param("today") LocalDate today);
+}

--- a/src/main/java/org/scoula/email/controller/AlertsTestController.java
+++ b/src/main/java/org/scoula/email/controller/AlertsTestController.java
@@ -1,0 +1,25 @@
+package org.scoula.email.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.scoula.email.scheduled.AlertScheduler;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/test/alert")
+@RequiredArgsConstructor
+public class AlertsTestController {
+
+    private final AlertScheduler alertScheduler;
+
+    // 테스트용 코드
+    @GetMapping("/run")
+    public ResponseEntity<Map<String, String>> runAlert() {
+        alertScheduler.sendApplicationDateAlert();
+        return ResponseEntity.ok(Map.of("message", "알림 테스트 실행됨"));
+    }
+}

--- a/src/main/java/org/scoula/email/controller/EmailController.java
+++ b/src/main/java/org/scoula/email/controller/EmailController.java
@@ -1,4 +1,4 @@
-package org.scoula.email.scheduled;
+package org.scoula.email.controller;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;

--- a/src/main/java/org/scoula/email/scheduled/AlertScheduler.java
+++ b/src/main/java/org/scoula/email/scheduled/AlertScheduler.java
@@ -1,0 +1,29 @@
+package org.scoula.email.scheduled;
+
+import lombok.RequiredArgsConstructor;
+import org.scoula.bookmark.dto.BookmarkEmailInfo;
+import org.scoula.bookmark.mapper.BookmarkMapper;
+import org.scoula.email.service.MailService;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AlertScheduler {
+
+    private final BookmarkMapper bookmarkMapper;
+    private final MailService mailService;
+
+//    @Scheduled(cron = "0 0 8 * * *") 테스트용 주석
+    public void sendApplicationDateAlert() {
+        LocalDate today = LocalDate.now();
+        List<BookmarkEmailInfo> alerts = bookmarkMapper.findAlertsForToday(today);
+
+        for (BookmarkEmailInfo info : alerts) {
+            mailService.sendCustomAlertMail(info.getEmail(), info.getTitle(), info.getType());
+        }
+    }
+}

--- a/src/main/java/org/scoula/email/scheduled/EmailController.java
+++ b/src/main/java/org/scoula/email/scheduled/EmailController.java
@@ -1,4 +1,4 @@
-package org.scoula.email.controller;
+package org.scoula.email.scheduled;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -8,7 +8,6 @@ import org.scoula.auth.dto.AuthResponse;
 import org.scoula.email.dto.EmailDTO;
 import org.scoula.email.dto.EmailRequestDto;
 import org.scoula.email.service.MailService;
-import org.scoula.email.service.MailServiceImpl;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/src/main/java/org/scoula/email/service/MailService.java
+++ b/src/main/java/org/scoula/email/service/MailService.java
@@ -11,4 +11,6 @@ public interface MailService {
     public MimeMessage createMail(String mail);
     public int sendMail(String mail);
     public EmailDTO mailCheck(EmailRequestDto requestDto, HttpSession session);
+
+    public void sendCustomAlertMail(String toEmail, String danziTitle, String type);
 }

--- a/src/main/java/org/scoula/email/service/MailServiceImpl.java
+++ b/src/main/java/org/scoula/email/service/MailServiceImpl.java
@@ -10,6 +10,7 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 
 import javax.mail.MessagingException;
+import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
 import javax.servlet.http.HttpSession;
@@ -117,6 +118,28 @@ public class MailServiceImpl implements MailService {
                             .isSuccess(false)
                             .message("에러 발생")
                             .build();
+        }
+    }
+
+    @Override
+    public void sendCustomAlertMail(String toEmail, String danziTitle, String type) {
+        MimeMessage message = javaMailSender.createMimeMessage();
+        try {
+            message.setFrom(new InternetAddress(senderEmail));
+            message.setRecipients(MimeMessage.RecipientType.TO, InternetAddress.parse(toEmail));
+            message.setSubject("[청약 알림] " + danziTitle + " - " + type);
+
+            String body = "<h3>[" + danziTitle + "]</h3>"
+                    + "<p>오늘은 '" + type + "' 입니다.</p>"
+                    + "<p>청약 일정을 꼭 확인하세요.</p>";
+
+            message.setText(body, "UTF-8", "html");
+            javaMailSender.send(message);
+
+            System.out.println("[이메일 알림] 수신자: " + toEmail + ", 제목: " + danziTitle + ", 종류: " + type);
+
+        } catch (MessagingException e) {
+            e.printStackTrace();
         }
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,16 +1,16 @@
 #driver=com.mysql.cj.jdbc.Driver
 #url=jdbc:mysql://127.0.0.1:3306/scoula_db
 
-#jdbc.driver=net.sf.log4jdbc.sql.jdbcapi.DriverSpy
-#jdbc.url=jdbc:log4jdbc:mysql://myhomecatch.cpw20yo0imjn.ap-southeast-2.rds.amazonaws.com:3306/MyHomeCatch
-#jdbc.username=root
-#jdbc.password=myhomecatch
+jdbc.driver=net.sf.log4jdbc.sql.jdbcapi.DriverSpy
+jdbc.url=jdbc:log4jdbc:mysql://myhomecatch.cpw20yo0imjn.ap-southeast-2.rds.amazonaws.com:3306/MyHomeCatch
+jdbc.username=root
+jdbc.password=myhomecatch
 LH_API_SERVICE_KEY=EKnz94vtAe4ueCv7XJwzzUrA3HHKz2%2BDTAtvnHJNt5yjoVZMo%2Bqqk1hV%2FApwknZ0slBYc%2BXKooVXHoE8woxEpw%3D%3D
 
-jdbc.driver=net.sf.log4jdbc.sql.jdbcapi.DriverSpy
-jdbc.url=jdbc:log4jdbc:mysql://localhost:3306/scoula_db
-jdbc.username=scoula
-jdbc.password=1234
+#jdbc.driver=net.sf.log4jdbc.sql.jdbcapi.DriverSpy
+#jdbc.url=jdbc:log4jdbc:mysql://localhost:3306/scoula_db
+#jdbc.username=scoula
+#jdbc.password=1234
 
 kakao.clientId=b5cd13baf980b9b75f7494d8d4c946bd
 kakao.redirectUrl=http://localhost:5173/auth/loading

--- a/src/main/resources/org/scoula/bookmark/mapper/BookmarkMapper.xml
+++ b/src/main/resources/org/scoula/bookmark/mapper/BookmarkMapper.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.scoula.bookmark.mapper.BookmarkMapper">
+
+    <select id="findAlertsForToday" resultType="org.scoula.bookmark.dto.BookmarkEmailInfo">
+        SELECT u.email,
+               d.bzdt_nm AS title,
+               CASE
+                   WHEN da.sbsc_acp_st_dt = #{today} THEN '접수 시작일'
+                   WHEN da.sbsc_acp_clsg_dt = #{today} THEN '접수 마감일'
+                   END AS type
+        FROM bookmarks b
+                 JOIN users u ON b.user_id = u.user_id
+                 JOIN danzi_apply da ON b.apply_id = da.apply_id
+                 JOIN danzi d ON da.danzi_id = d.danzi_id
+        WHERE da.sbsc_acp_st_dt = #{today}
+           OR da.sbsc_acp_clsg_dt = #{today};
+    </select>
+</mapper>


### PR DESCRIPTION
## 연관된 이슈

## 작업 내용
- 즐겨찾기를 한 공고 중 시작일, 마감일이 오늘에 해당하면 이메일 전송
- Schduled를 통해 스케쥴링 (매일 8시 기준)

## API endpoint 사항
### AlertTestController(/test/alert)
!!! 테스트용 컨트롤러  !!!
| Method | Endpoint       | 설명                             |
|--------|----------------|----------------------------------|
| GET  | `/run`        | 현재 날짜 기준 시작일, 마감일 해당 시 이메일 발송    |

## Schduled
- 매일 8시에 bookmarks 테이블 확인 이후 시작일, 마감일에 해당하는 공고 존재 시
   유저의 이메일 주소로 이메일 발송
   
## SQL
```
CREATE TABLE bookmarks (
    user_id INT NOT NULL,
    apply_id INT NOT NULL,
    PRIMARY KEY (user_id, apply_id),
    FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE,
    FOREIGN KEY (apply_id) REFERENCES danzi_apply(apply_id)
) COMMENT='즐겨찾기 테이블';
```