### PR TITLE
FEAT: 오늘 신청 가능 청약 개수 조회 api 추가

### DIFF
--- a/src/main/java/org/scoula/calendar/controller/CalendarController.java
+++ b/src/main/java/org/scoula/calendar/controller/CalendarController.java
@@ -23,4 +23,9 @@ public class CalendarController {
     public ResponseEntity<CalendarResponseDTO> getCalendar(@RequestParam String date) {
         return ResponseEntity.ok(calendarService.getCalendar(date));
     }
+
+    @GetMapping("/today")
+    public ResponseEntity<Integer> getApplyToday(@RequestParam String date) {
+        return ResponseEntity.ok(calendarService.getToday(date));
+    }
 }

--- a/src/main/java/org/scoula/calendar/mapper/CalendarMapper.java
+++ b/src/main/java/org/scoula/calendar/mapper/CalendarMapper.java
@@ -9,4 +9,6 @@ import java.util.List;
 public interface CalendarMapper {
 
     List<CalendarVO> getCalendar(@Param("date") String date);
+
+    Integer getToday(@Param("date") String date);
 }

--- a/src/main/java/org/scoula/calendar/service/CalendarService.java
+++ b/src/main/java/org/scoula/calendar/service/CalendarService.java
@@ -7,4 +7,6 @@ import java.util.List;
 public interface CalendarService {
 
     CalendarResponseDTO getCalendar(String date);
+
+    Integer getToday(String date);
 }

--- a/src/main/java/org/scoula/calendar/service/CalendarServiceImpl.java
+++ b/src/main/java/org/scoula/calendar/service/CalendarServiceImpl.java
@@ -29,4 +29,9 @@ public class CalendarServiceImpl implements CalendarService {
                 .dataList(calendarList)
                 .build();
     }
+
+    @Override
+    public Integer getToday(String date) {
+        return calendarMapper.getToday(date);
+    }
 }

--- a/src/main/resources/org/scoula/calendar/mapper/CalendarMapper.xml
+++ b/src/main/resources/org/scoula/calendar/mapper/CalendarMapper.xml
@@ -25,6 +25,15 @@
         ORDER BY da.sbsc_acp_st_dt;
     </select>
 
+    <select id="getToday" resultType="Integer">
+    <![CDATA[
+        SELECT COUNT(*) AS danzi_count
+        FROM danzi_apply
+        WHERE sbsc_acp_st_dt <= STR_TO_DATE(#{date}, '%Y.%m.%d')
+          AND sbsc_acp_clsg_dt >= STR_TO_DATE(#{date}, '%Y.%m.%d')
+        ]]>
+</select>
+
     <resultMap id="calendarResultMap" type="org.scoula.calendar.domain.CalendarVO">
 <!--        <id property="danzi_id" column="danzi_id" />-->
         <result property="danzi_id" column="danzi_id" />


### PR DESCRIPTION
## 작업 내용
- 오늘 청약 일정 개수 조회 API

## API endpoint 사항
###  CalendarContoller(/calendar)

| Method | Endpoint       | 설명                             |
|--------|----------------|----------------------------------|
| GET |   `/today?date={date}`      |  오늘 신청 가능한 청약 개수 조회        |